### PR TITLE
Added Apache 2.0 license.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2014 Guardian News & Media Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package.json
+++ b/package.json
@@ -16,5 +16,10 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/guardian/scribe-plugin-keyboard-shortcuts.git"
-  }
+  },
+  "licenses": [
+    {
+      "type": "Apache2"
+    }
+  ]
 }


### PR DESCRIPTION
Supersedes https://github.com/guardian/scribe-plugin-keyboard-shortcuts/pull/4.